### PR TITLE
Update zoxide to v0.2.2.

### DIFF
--- a/zoxide.rb
+++ b/zoxide.rb
@@ -1,8 +1,8 @@
 class Zoxide < Formula
   desc "A fast cd command that learns your habits"
   homepage "https://github.com/ajeetdsouza/zoxide"
-  url "https://github.com/ajeetdsouza/zoxide/archive/v0.2.1.tar.gz"
-  sha256 "0026622781ae04323512a70eb25939c3134f3e07a1f7a0a5d84d5cbb2d4e5136"
+  url "https://github.com/ajeetdsouza/zoxide/archive/v0.2.2.tar.gz"
+  sha256 "3e7b2b1f2fed579f61614f982afd325d626b115d8fae0590877c73fda4110279"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
Saw that v0.2.2 included some exit code fixes that I'd love to fetch. Thanks for the great project, @ajeetdsouza 